### PR TITLE
Use erp_build_number instead of erp_latest_build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Role Variables
 
 | variable | description | default
 |----------|-------------|---------
-| erp_latest_build | ERP build number | No default - required
+| erp_build_number | ERP build number | No default - required
 | erp_squad_environment | [production|staging] | production
 | erp_squad_auth_token | Squad API auth token | No default - required
 
@@ -16,14 +16,16 @@ Role Variables
 Dependencies
 ------------
 
-If ansible-role-erp-get-build is run first, then erp_latest_build will be set.
+If ansible-role-erp-get-build is run first, then erp_build_number will be set.
 Otherwise, it must be set to the erp build number that is installed on the
 host.
 
 Example Playbook
 ----------------
 
-    - hosts: servers
+    - hosts: all
+      vars:
+        erp_build_number: 454 # ERP build installed on host
       roles:
         - role: Linaro.erp-run-test-suite
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,16 +3,16 @@
   assert:
     that: "{{ item }} is defined"
   with_items:
-    - erp_latest_build
+    - erp_build_number
     - erp_squad_environment
     - erp_squad_auth_token
 
 - name: Gather Facts
   setup:
 
-- name: Check for /root/test-definitions
+- name: Check for previous run
   stat:
-    path: /root/test-definitions
+    path: /root/run_erp_suite.stdout.log
   register: tests_run
 - name: Verify host is clean
   fail:
@@ -53,6 +53,6 @@
 
 - name: Run ERP test suite
   # daemon --name ensures only one runs at a time
-  command: daemon --name=erp_suite --errlog=/root/run_erp_suite.stderr.log --dbglog=/root/run_erp_suite.stdout.log -- /root/run_erp_suite.sh {{erp_latest_build}}
+  command: daemon --name=erp_suite --errlog=/root/run_erp_suite.stderr.log --dbglog=/root/run_erp_suite.stdout.log -- /root/run_erp_suite.sh {{erp_build_number}}
   environment:
     SQUAD_AUTH_TOKEN: "{{erp_squad_auth_token}}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   vars:
-    erp_latest_build: 430
+    erp_build_number: 430
     erp_squad_auth_token: XXX
   roles:
     - role_under_test


### PR DESCRIPTION
- Change variable name - don't assume latest
- When checking for previous run, check output file not git checkout

Signed-off-by: Dan Rue <dan.rue@linaro.org>