### PR TITLE
run_erp_suite.sh: Remove timestamps from apt cache

### DIFF
--- a/templates/run_erp_suite.sh
+++ b/templates/run_erp_suite.sh
@@ -6,7 +6,7 @@ if [ -z $1 ]; then
 fi
 
 report_url="{{erp_squad_url[erp_squad_environment]}}"
-plans="plans/erp/erp-functional.yaml plans/erp/erp-enterprise.yaml plans/erp/erp-performance.yaml plans/erp/erp-ltp.yaml"
+plans="plans/erp/erp-functional.yaml plans/erp/erp-enterprise.yaml plans/erp/erp-ltp.yaml plans/erp/erp-performance.yaml"
 
 root_path=/root
 td_path=${root_path}/test-definitions
@@ -18,7 +18,12 @@ os_name=$(slugify `grep ^ID= /etc/os-release | awk -F= '{print $2}'`)
 
 cd ${td_path}
 . ./automated/bin/setenv.sh
-build_id=$1-$(apt-cache dump | md5sum | cut -c -8)
+
+# Calculate a unique build id based on the build number but also the contents
+# of the local apt-cache, so that when the available set of packages changes,
+# the build id changes. Remove "^ Time" from the results because the dpkg
+# status file seems to be dynamically generated and contains a timestamp.
+build_id=$1-$(apt-cache dump | grep -v "^ Time" | md5sum | cut -c -8)
 
 for plan in ${plans}; do
     plan_short=$(basename -s .yaml ${plan})


### PR DESCRIPTION
Calculate a unique build id based on the build number but also the
contents of the local apt-cache, so that when the available set of
packages changes, the build id changes. Remove "^ Time" from the results
because the dpkg status file seems to be dynamically generated and
contains a timestamp.

Also, reorder test plans to have performance be last.

Signed-off-by: Dan Rue <dan.rue@linaro.org>