### PR TITLE
Power off SUT after tests finished

### DIFF
--- a/templates/run_erp_suite.sh
+++ b/templates/run_erp_suite.sh
@@ -53,3 +53,6 @@ for plan in ${plans}; do
                   -p {{erp_debian_installer_environment}}-debian \
                   > ${output_path}/post-to-squad.log 2>&1
 done
+
+# Power off SUT to release it.
+poweroff


### PR DESCRIPTION
After tests finished properly, power off the SUT so that test scheduler
able to know tests finished.

Signed-off-by: Chase Qi <chase.qi@linaro.org>