### PR TITLE
Add support for customized vendor/board name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,3 +54,5 @@
   shell: nohup /root/run_erp_suite.sh {{erp_build_number}} > /root/run_erp_suite.stdout.log 2>/root/run_erp_suite.stderr.log &
   environment:
     SQUAD_AUTH_TOKEN: "{{erp_squad_auth_token}}"
+    vendor_name: "{{vendor_name | default('')}}"
+    board_name: "{{board_name | default('')}}"

--- a/templates/run_erp_suite.sh
+++ b/templates/run_erp_suite.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 if [ -z $1 ]; then
     echo "Usage: $0 <build_number>"
     exit 1
@@ -16,8 +18,8 @@ root_path=/root
 td_path=${root_path}/test-definitions
 
 # Gather environmental info for erp project and environment names
-vendor_name=$(slugify `cat /sys/devices/virtual/dmi/id/board_vendor`)
-board_name=$(slugify `cat /sys/devices/virtual/dmi/id/board_name`)
+[ -n "${vendor_name}" ] || vendor_name=$(slugify `cat /sys/devices/virtual/dmi/id/board_vendor`)
+[ -n "${board_name}" ] || board_name=$(slugify `cat /sys/devices/virtual/dmi/id/board_name`)
 os_name=$(slugify `grep ^ID= /etc/os-release | awk -F= '{print $2}'`)
 
 cd ${td_path}
@@ -50,6 +52,7 @@ for plan in ${plans}; do
                   -a ${output_path}/test-runner-stderr.log \
                   -u ${report_url} \
                   -t erp-${vendor_name} \
+                  -e ${board_name}
                   -p {{erp_debian_installer_environment}}-debian \
                   > ${output_path}/post-to-squad.log 2>&1
 done


### PR DESCRIPTION
On qualcomm centriq 2400 server,

    root@debian:~# cat /sys/devices/virtual/dmi/id/board_vendor
    WIWYNN
    root@debian:~# cat /sys/devices/virtual/dmi/id/board_name
    Qualcomm Centriq 2400 Customer Reference Board

The desired names are 'qualcomm' for vender_name and 'centriq-2400' for
board_name.

This patch:

* Use vendor/board name set in hosts by default. If it is not set,
  failover to the name get from DMI.
* Enable xtrace for debugging.

Signed-off-by: Chase Qi <chase.qi@linaro.org>