### PR TITLE
Add gathered facts dump

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,9 @@
 - name: Gather Facts
   setup:
 
+- name: Print out the gathered facts
+  debug: var=hostvars[inventory_hostname]
+
 - name: Check for previous run
   stat:
     path: /root/run_erp_suite.stdout.log


### PR DESCRIPTION
Since we are gathering facts on the machines, we might as well dump them directly in the Ansible output (thus Jenkins console) to easily check for various environment settings, and especially the kernel version.

Note that the output is quite thorough, and thus long, so it will require using the Find tool, and will "bloat" Jenkins' console output, but it allows for in-depth knowledge on the state of the machine after provisioning, prior to running the test suite at first glance on the job.

The facts could also be dumped to a Manifest file (instead), which would save the Jenkins console some readability.

This addresses : https://github.com/Linaro/erp-test-automation/issues/16